### PR TITLE
External entropy

### DIFF
--- a/source/ulid.cpp
+++ b/source/ulid.cpp
@@ -87,6 +87,31 @@ static void ulid_create(u8* ulid_buffer)
     ulid_buffer[15] = num;
 }
 
+static void ulid_create(u8* ulid_buffer, const u8 (&entropy)[10])
+{
+    using namespace std::chrono;
+    const auto time_epoc = system_clock::now().time_since_epoch();
+    const auto timestamp = duration_cast<std::chrono::milliseconds>(time_epoc).count();
+
+    ulid_buffer[0] = timestamp >> 40;
+    ulid_buffer[1] = timestamp >> 32;
+    ulid_buffer[2] = timestamp >> 24;
+    ulid_buffer[3] = timestamp >> 16;
+    ulid_buffer[4] = timestamp >> 8;
+    ulid_buffer[5] = timestamp >> 0;
+
+    ulid_buffer[6] = entropy[0];
+    ulid_buffer[7] = entropy[1];
+    ulid_buffer[8] = entropy[2];
+    ulid_buffer[9] = entropy[3];
+    ulid_buffer[10] = entropy[4];
+    ulid_buffer[11] = entropy[5];
+    ulid_buffer[12] = entropy[6];
+    ulid_buffer[13] = entropy[7];
+    ulid_buffer[14] = entropy[8];
+    ulid_buffer[15] = entropy[9];
+}
+
 static void ulid_encode(const u8* ulid_data, u8* output)
 {
     constexpr char lookup[] = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
@@ -178,6 +203,13 @@ ulid_t generate()
 {
     ulid_t out;
     ulid_create(out.bits);
+    return out;
+}
+
+ulid_t generate(const u8 (&entropy)[10])
+{
+    ulid_t out;
+    ulid_create(out.bits, entropy);
     return out;
 }
 

--- a/source/ulid.cpp
+++ b/source/ulid.cpp
@@ -47,17 +47,15 @@ static u64 seed()
 static std::atomic<u64> state = seed();
 static u64 rng()
 {
-    u64 number = state.load(std::memory_order_relaxed);
-    u64 expected = number;
-    number ^= number >> 12;
-    number ^= number << 25;
-    number ^= number >> 27;
-    while (!state.compare_exchange_weak(expected, number, std::memory_order_relaxed)) {
+    u64 expected = state.load(std::memory_order_relaxed);
+    u64 number;
+    do {
         number = expected;
         number ^= number >> 12;
         number ^= number << 25;
         number ^= number >> 27;
-    }
+    } while (!state.compare_exchange_weak(expected, number, std::memory_order_relaxed));
+
     return number * 0x2545F4914F6CDD1DULL;
 }
 

--- a/source/ulid.h
+++ b/source/ulid.h
@@ -30,8 +30,8 @@
 #include <string_view>
 
 namespace ulid {
+using u8 = unsigned char;
 struct ulid_t {
-    using u8 = unsigned char;
     u8 bits[16];
 
     /**
@@ -44,6 +44,11 @@ struct ulid_t {
  * Generate a new ULID.
  */
 ulid_t generate();
+
+/**
+ * Generate a new ULID using the given entropy source.
+ */
+ulid_t generate(const u8 (&entropy)[10]);
 
 /**
  * Generate a new ULID string (26 characters) in the provided buffer and null terminate it.


### PR DESCRIPTION
Instead of using xorshift64* internally, add an API to generate a ULID
using random bytes provided by the caller. This might be handy for users
with a particular security concerns.
